### PR TITLE
ldflags after source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,5 @@ SOURCES = main.cpp
 TARGET = cellular
 
 all: main.cpp
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(SOURCES) -o $(TARGET)
+	$(CXX) $(CXXFLAGS) $(SOURCES) -o $(TARGET) $(LDFLAGS)
 


### PR DESCRIPTION
sdl gets optimized out if library flags come before the source file.